### PR TITLE
Fixes analyzer exclude (#7)

### DIFF
--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -16,6 +16,7 @@ class Settings {
     }
     final contents = file.readAsStringSync();
     final yaml = loadYaml(contents);
+    if (yaml is! YamlMap) return const Settings();
 
     final analyzerSection = yaml['analyzer'];
     final excludePatterns = <String>[];

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:yaml/yaml.dart';
 
+import 'utils.dart';
+
 class Settings {
   static Settings loadFromAnalysisOptions([String? rootPath]) {
     final file = File(
@@ -14,22 +16,45 @@ class Settings {
     }
     final contents = file.readAsStringSync();
     final yaml = loadYaml(contents);
+
+    final analyzerSection = yaml['analyzer'];
+    final excludePatterns = <String>[];
+    if (analyzerSection is YamlMap) {
+      final exclude = analyzerSection['exclude'];
+      if (exclude is YamlList) {
+        excludePatterns.addAll(exclude.whereType<String>());
+      }
+    }
+
     final preferShorthands = yaml['prefer_shorthands'];
     if (preferShorthands is! YamlMap) {
-      return const Settings();
+      return Settings(excludePatterns: excludePatterns);
     }
 
     return Settings(
       convertImplicitDeclaration: preferShorthands.getKeyAsTypeOrNull<bool>(
         'convert_implicit_declaration',
       ),
+      excludePatterns: excludePatterns,
     );
   }
 
-  const Settings({bool? convertImplicitDeclaration})
-    : convertImplicitDeclaration = convertImplicitDeclaration ?? false;
+  const Settings({bool? convertImplicitDeclaration, List<String>? excludePatterns})
+    : convertImplicitDeclaration = convertImplicitDeclaration ?? false,
+      excludePatterns = excludePatterns ?? const [];
 
   final bool convertImplicitDeclaration;
+  final List<String> excludePatterns;
+
+  bool isExcluded(String filePath, String rootPath) {
+    var relative = filePath.replaceAll('\\', '/');
+    final root = rootPath.replaceAll('\\', '/');
+    if (root.isNotEmpty && relative.startsWith(root)) {
+      relative = relative.substring(root.length);
+      if (relative.startsWith('/')) relative = relative.substring(1);
+    }
+    return excludePatterns.any((p) => matchesGlobPattern(p, relative));
+  }
 
   @override
   String toString() =>

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -40,9 +40,11 @@ class Settings {
     );
   }
 
-  const Settings({bool? convertImplicitDeclaration, List<String>? excludePatterns})
-    : convertImplicitDeclaration = convertImplicitDeclaration ?? false,
-      excludePatterns = excludePatterns ?? const [];
+  const Settings({
+    bool? convertImplicitDeclaration,
+    List<String>? excludePatterns,
+  }) : convertImplicitDeclaration = convertImplicitDeclaration ?? false,
+       excludePatterns = excludePatterns ?? const [];
 
   final bool convertImplicitDeclaration;
   final List<String> excludePatterns;

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -165,6 +165,35 @@ extension TypedLiteralExtension on TypedLiteral {
 
 enum IterableType { set, list, mapValue, mapKey }
 
+bool matchesGlobPattern(String pattern, String filePath) {
+  final path = filePath.replaceAll('\\', '/');
+  var regexStr = '';
+  var i = 0;
+  final p = pattern.replaceAll('\\', '/');
+  while (i < p.length) {
+    final ch = p[i];
+    if (ch == '*' && i + 1 < p.length && p[i + 1] == '*') {
+      if (i + 2 < p.length && p[i + 2] == '/') {
+        regexStr += '(?:.+/)?';
+        i += 3;
+      } else {
+        regexStr += '.*';
+        i += 2;
+      }
+    } else if (ch == '*') {
+      regexStr += '[^/]*';
+      i++;
+    } else if (RegExp(r'[.+^${}()|[\]]').hasMatch(ch)) {
+      regexStr += '\\$ch';
+      i++;
+    } else {
+      regexStr += ch;
+      i++;
+    }
+  }
+  return RegExp('^$regexStr\$').hasMatch(path);
+}
+
 extension AstNodeExtension on AstNode {
   DartType? findDeclaredType() {
     final varDecl = thisOrAncestorOfType<VariableDeclaration>();

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -33,6 +33,26 @@ extension DartTypeExtension on DartType {
   };
 }
 
+extension RecordLiteralFieldExtension on RecordLiteralField {
+  Expression get expressionValue {
+    if (this case RecordLiteralNamedField(:final fieldExpression)) {
+      return fieldExpression;
+    }
+    if (this is Expression) {
+      return this as Expression;
+    }
+
+    throw StateError('Unexpected record literal field: $runtimeType');
+  }
+
+  bool get isNamedRecordField => this is RecordLiteralNamedField;
+
+  String? get namedRecordFieldName => switch (this) {
+    RecordLiteralNamedField(:final name) => name.lexeme,
+    _ => null,
+  };
+}
+
 extension ExpressionExtension on Expression {
   String? get constructorNameIfInstanceCreation => switch (this) {
     InstanceCreationExpression(
@@ -130,10 +150,8 @@ extension TypedLiteralExtension on TypedLiteral {
         ),
       ) =>
         type,
-      DefaultFormalParameter(
-        parameter: SimpleFormalParameter(
-          type: NamedType(:final InterfaceType type),
-        ),
+      FormalParameterDefaultClause(
+        parent: FormalParameter(type: NamedType(:final InterfaceType type)),
       ) =>
         type,
       _ => null,

--- a/lib/visitor.dart
+++ b/lib/visitor.dart
@@ -78,6 +78,15 @@ class Visitor extends SimpleAstVisitor<void> {
       }
     }
 
+    final filePath = context.currentUnit?.file.path;
+    if (filePath != null &&
+        plugin.settings.isExcluded(
+          filePath,
+          context.package?.root.path ?? '',
+        )) {
+      return;
+    }
+
     rule.reportAtNode(expression);
   }
 

--- a/lib/visitor.dart
+++ b/lib/visitor.dart
@@ -37,7 +37,7 @@ class Visitor extends SimpleAstVisitor<void> {
     registry.addIfElement(rule, this);
     registry.addForElement(rule, this);
     registry.addMapLiteralEntry(rule, this);
-    registry.addDefaultFormalParameter(rule, this);
+    registry.addFormalParameterDefaultClause(rule, this);
     registry.addReturnStatement(rule, this);
     registry.addExpressionFunctionBody(rule, this);
     registry.addSwitchExpressionCase(rule, this);
@@ -135,17 +135,14 @@ class Visitor extends SimpleAstVisitor<void> {
       if (declaredType == null) continue;
 
       while (literalIndex < literal.fields.length &&
-          literal.fields[literalIndex] is NamedExpression) {
+          literal.fields[literalIndex].isNamedRecordField) {
         literalIndex++;
       }
 
       if (literalIndex >= literal.fields.length) break;
 
       final literalField = literal.fields[literalIndex];
-      final expression = switch (literalField) {
-        NamedExpression(:final expression) => expression,
-        _ => literalField,
-      };
+      final expression = literalField.expressionValue;
 
       if (!expression.isDotShorthand) {
         _checkAndReport(expression: expression, declaredType: declaredType);
@@ -161,9 +158,8 @@ class Visitor extends SimpleAstVisitor<void> {
         if (declaredType == null) continue;
 
         for (final literalField in literal.fields) {
-          if (literalField is NamedExpression &&
-              literalField.name.label.name == fieldName) {
-            final expression = literalField.expression;
+          if (literalField.namedRecordFieldName == fieldName) {
+            final expression = literalField.expressionValue;
             if (!expression.isDotShorthand) {
               _checkAndReport(
                 expression: expression,
@@ -203,10 +199,7 @@ class Visitor extends SimpleAstVisitor<void> {
       };
       if (declaredType == null) continue;
 
-      final expression = switch (literalField) {
-        NamedExpression(:final expression) => expression,
-        _ => literalField,
-      };
+      final expression = literalField.expressionValue;
 
       if (!expression.isDotShorthand) {
         _checkAndReport(expression: expression, declaredType: declaredType);
@@ -286,10 +279,7 @@ class Visitor extends SimpleAstVisitor<void> {
   @override
   void visitArgumentList(ArgumentList node) {
     for (final argument in node.arguments) {
-      final expression = switch (argument) {
-        NamedExpression(:final expression) => expression,
-        _ => argument,
-      };
+      final expression = argument.argumentExpression;
 
       if (expression.isDotShorthand) continue;
 
@@ -297,8 +287,7 @@ class Visitor extends SimpleAstVisitor<void> {
       final baseType = parameter?.baseElement.type;
 
       if (baseType is TypeParameterType) {
-        final hasExplicitContext = argument.hasExplicitTypeContext;
-        if (!hasExplicitContext) continue;
+        if (!expression.hasExplicitTypeContext) continue;
       }
 
       _checkAndReport(expression: expression, declaredType: parameter?.type);
@@ -350,18 +339,14 @@ class Visitor extends SimpleAstVisitor<void> {
 
     var positionalIndex = 0;
     for (final field in node.fields) {
-      final expression = switch (field) {
-        NamedExpression(:final expression) => expression,
-        _ => field,
-      };
+      final expression = field.expressionValue;
 
       if (expression.isDotShorthand) {
-        if (field is! NamedExpression) positionalIndex++;
+        if (!field.isNamedRecordField) positionalIndex++;
         continue;
       }
 
-      // Get the expected type for this field
-      final fieldName = field is NamedExpression ? field.name.label.name : null;
+      final fieldName = field.namedRecordFieldName;
       final fieldType = recordType.getFieldTypeByNameOrIndex(
         positionalIndex,
         fieldName,
@@ -371,18 +356,17 @@ class Visitor extends SimpleAstVisitor<void> {
         _checkAndReport(expression: expression, declaredType: fieldType);
       }
 
-      if (field is! NamedExpression) positionalIndex++;
+      if (!field.isNamedRecordField) positionalIndex++;
     }
   }
 
   @override
-  void visitDefaultFormalParameter(DefaultFormalParameter node) {
-    final expression = node.defaultValue;
-    if (expression == null) return;
+  void visitFormalParameterDefaultClause(FormalParameterDefaultClause node) {
+    final expression = node.value;
     if (expression.isDotShorthand) return;
 
-    final declaredType = switch (node.parameter) {
-      SimpleFormalParameter(type: NamedType(type: final type)) => type,
+    final declaredType = switch (node.parent) {
+      FormalParameter(type: NamedType(type: final type)) => type,
       _ => null,
     };
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: prefer_shorthands
 description: An analyzer plugin that suggests using Dart's dot shorthand syntax.
 homepage: https://github.com/huanghui1998hhh/prefer_shorthands
-version: 0.4.7
+version: 0.5.0
 
 keywords:
   - dart
@@ -25,6 +25,6 @@ dev_dependencies:
   lints: ^6.0.0
   test: ^1.25.6
   coverage: ^1.8.0
-  
+
   analyzer_testing: ^0.1.5
   test_reflective_loader: ^0.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: ^3.10.0-0
 
 dependencies:
-  analysis_server_plugin: ^0.3.15
+  analysis_server_plugin: ^0.3.14
   analyzer: ">=10.0.0 <13.0.0"
   analyzer_plugin: ^0.14.8
   meta: ^1.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 
 dependencies:
   analysis_server_plugin: ^0.3.0
-  analyzer: ">=8.0.0 <10.0.0"
+  analyzer: ">=10.0.0 <13.0.0"
   analyzer_plugin: ^0.13.10
   meta: ^1.3.0
   yaml: ^3.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 
 dependencies:
   analysis_server_plugin: ^0.3.14
-  analyzer: ">=10.0.0 <13.0.0"
+  analyzer: ^12.1.0
   analyzer_plugin: ^0.14.8
   meta: ^1.3.0
   yaml: ^3.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 dependencies:
   analysis_server_plugin: ^0.3.15
   analyzer: ">=10.0.0 <13.0.0"
-  analyzer_plugin: ^0.14.9
+  analyzer_plugin: ^0.13.11
   meta: ^1.3.0
   yaml: ^3.1.3
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,9 +15,9 @@ environment:
   sdk: ^3.10.0-0
 
 dependencies:
-  analysis_server_plugin: ^0.3.0
+  analysis_server_plugin: ^0.3.15
   analyzer: ">=10.0.0 <13.0.0"
-  analyzer_plugin: ^0.13.10
+  analyzer_plugin: ^0.14.9
   meta: ^1.3.0
   yaml: ^3.1.3
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,9 +15,9 @@ environment:
   sdk: ^3.10.0-0
 
 dependencies:
-  analysis_server_plugin: ^0.3.14
-  analyzer: ^12.1.0
-  analyzer_plugin: ^0.14.8
+  analysis_server_plugin: ^0.3.15
+  analyzer: ^13.0.0
+  analyzer_plugin: ^0.14.9
   meta: ^1.3.0
   yaml: ^3.1.3
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   sdk: ^3.10.0-0
 
 dependencies:
-  analysis_server_plugin: ^0.3.15
+  analysis_server_plugin: ">=0.3.15 <0.3.16"
   analyzer: ^13.0.0
   analyzer_plugin: ^0.14.9
   meta: ^1.3.0
@@ -26,5 +26,5 @@ dev_dependencies:
   test: ^1.25.6
   coverage: ^1.8.0
 
-  analyzer_testing: ^0.1.5
+  analyzer_testing: ^0.2.6
   test_reflective_loader: ^0.4.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 dependencies:
   analysis_server_plugin: ^0.3.15
   analyzer: ">=10.0.0 <13.0.0"
-  analyzer_plugin: ^0.13.11
+  analyzer_plugin: ^0.14.8
   meta: ^1.3.0
   yaml: ^3.1.3
 

--- a/test/exclusion_test.dart
+++ b/test/exclusion_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:prefer_shorthands/settings.dart';
 import 'package:prefer_shorthands/utils.dart';
 import 'package:test/test.dart';
@@ -51,6 +53,73 @@ void main() {
         matchesGlobPattern('**/*.g.dart', r'lib\src\models.g.dart'),
         isTrue,
       );
+    });
+  });
+
+  group('Settings.loadFromAnalysisOptions', () {
+    late Directory tempDir;
+
+    setUp(() => tempDir = Directory.systemTemp.createTempSync('prefer_shorthands_test_'));
+    tearDown(() => tempDir.deleteSync(recursive: true));
+
+    void writeOptions(String content) =>
+        File('${tempDir.path}/analysis_options.yaml').writeAsStringSync(content);
+
+    test('reads analyzer.exclude patterns', () {
+      writeOptions('''
+analyzer:
+  exclude:
+    - "**/*.g.dart"
+    - "lib/generated/**"
+''');
+      final settings = Settings.loadFromAnalysisOptions(tempDir.path);
+      expect(settings.excludePatterns, ['**/*.g.dart', 'lib/generated/**']);
+    });
+
+    test('works without prefer_shorthands section', () {
+      writeOptions('''
+analyzer:
+  exclude:
+    - "**/*.g.dart"
+''');
+      final settings = Settings.loadFromAnalysisOptions(tempDir.path);
+      expect(settings.excludePatterns, ['**/*.g.dart']);
+      expect(settings.convertImplicitDeclaration, isFalse);
+    });
+
+    test('combines analyzer.exclude with prefer_shorthands options', () {
+      writeOptions('''
+analyzer:
+  exclude:
+    - "**/*.g.dart"
+
+prefer_shorthands:
+  convert_implicit_declaration: true
+''');
+      final settings = Settings.loadFromAnalysisOptions(tempDir.path);
+      expect(settings.excludePatterns, ['**/*.g.dart']);
+      expect(settings.convertImplicitDeclaration, isTrue);
+    });
+
+    test('returns empty patterns when no analyzer.exclude section', () {
+      writeOptions('''
+prefer_shorthands:
+  convert_implicit_declaration: true
+''');
+      final settings = Settings.loadFromAnalysisOptions(tempDir.path);
+      expect(settings.excludePatterns, isEmpty);
+    });
+
+    test('returns default settings when file does not exist', () {
+      final settings = Settings.loadFromAnalysisOptions(tempDir.path);
+      expect(settings.excludePatterns, isEmpty);
+      expect(settings.convertImplicitDeclaration, isFalse);
+    });
+
+    test('returns default settings when file is empty', () {
+      writeOptions('');
+      final settings = Settings.loadFromAnalysisOptions(tempDir.path);
+      expect(settings.excludePatterns, isEmpty);
     });
   });
 

--- a/test/exclusion_test.dart
+++ b/test/exclusion_test.dart
@@ -1,0 +1,95 @@
+import 'package:prefer_shorthands/settings.dart';
+import 'package:prefer_shorthands/utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('matchesGlobPattern', () {
+    test('matches **/*.g.dart in any directory', () {
+      expect(matchesGlobPattern('**/*.g.dart', 'lib/models.g.dart'), isTrue);
+      expect(matchesGlobPattern('**/*.g.dart', 'lib/src/models.g.dart'), isTrue);
+      expect(matchesGlobPattern('**/*.g.dart', 'models.g.dart'), isTrue);
+    });
+
+    test('does not match non-.g.dart files', () {
+      expect(matchesGlobPattern('**/*.g.dart', 'lib/models.dart'), isFalse);
+      expect(matchesGlobPattern('**/*.g.dart', 'lib/models.g.dart.bak'), isFalse);
+    });
+
+    test('matches directory wildcard pattern', () {
+      expect(
+        matchesGlobPattern('lib/generated/**', 'lib/generated/foo.dart'),
+        isTrue,
+      );
+      expect(
+        matchesGlobPattern('lib/generated/**', 'lib/generated/sub/foo.dart'),
+        isTrue,
+      );
+      expect(
+        matchesGlobPattern('lib/generated/**', 'lib/other/foo.dart'),
+        isFalse,
+      );
+    });
+
+    test('single * does not match path separators', () {
+      expect(matchesGlobPattern('*.dart', 'foo.dart'), isTrue);
+      expect(matchesGlobPattern('*.dart', 'lib/foo.dart'), isFalse);
+    });
+
+    test('dots in pattern are matched literally', () {
+      expect(
+        matchesGlobPattern('**/*.freezed.dart', 'lib/model.freezed.dart'),
+        isTrue,
+      );
+      expect(
+        matchesGlobPattern('**/*.freezed.dart', 'lib/modelXfreezedXdart'),
+        isFalse,
+      );
+    });
+
+    test('handles windows-style path separators in file path', () {
+      expect(
+        matchesGlobPattern('**/*.g.dart', r'lib\src\models.g.dart'),
+        isTrue,
+      );
+    });
+  });
+
+  group('Settings.isExcluded', () {
+    test('excludes file matching pattern', () {
+      final settings = Settings(excludePatterns: ['**/*.g.dart']);
+      expect(settings.isExcluded('/project/lib/model.g.dart', '/project'), isTrue);
+    });
+
+    test('does not exclude non-matching file', () {
+      final settings = Settings(excludePatterns: ['**/*.g.dart']);
+      expect(settings.isExcluded('/project/lib/model.dart', '/project'), isFalse);
+    });
+
+    test('excludes nested file matching pattern', () {
+      final settings = Settings(excludePatterns: ['**/*.g.dart']);
+      expect(
+        settings.isExcluded('/project/lib/src/model.g.dart', '/project'),
+        isTrue,
+      );
+    });
+
+    test('returns false when excludePatterns is empty', () {
+      const settings = Settings();
+      expect(settings.isExcluded('/project/lib/model.g.dart', '/project'), isFalse);
+    });
+
+    test('works when rootPath is empty', () {
+      final settings = Settings(excludePatterns: ['lib/model.g.dart']);
+      expect(settings.isExcluded('lib/model.g.dart', ''), isTrue);
+    });
+
+    test('supports multiple patterns', () {
+      final settings = Settings(
+        excludePatterns: ['**/*.g.dart', 'lib/generated/**'],
+      );
+      expect(settings.isExcluded('/p/lib/foo.g.dart', '/p'), isTrue);
+      expect(settings.isExcluded('/p/lib/generated/bar.dart', '/p'), isTrue);
+      expect(settings.isExcluded('/p/lib/normal.dart', '/p'), isFalse);
+    });
+  });
+}

--- a/test/exclusion_test.dart
+++ b/test/exclusion_test.dart
@@ -8,13 +8,19 @@ void main() {
   group('matchesGlobPattern', () {
     test('matches **/*.g.dart in any directory', () {
       expect(matchesGlobPattern('**/*.g.dart', 'lib/models.g.dart'), isTrue);
-      expect(matchesGlobPattern('**/*.g.dart', 'lib/src/models.g.dart'), isTrue);
+      expect(
+        matchesGlobPattern('**/*.g.dart', 'lib/src/models.g.dart'),
+        isTrue,
+      );
       expect(matchesGlobPattern('**/*.g.dart', 'models.g.dart'), isTrue);
     });
 
     test('does not match non-.g.dart files', () {
       expect(matchesGlobPattern('**/*.g.dart', 'lib/models.dart'), isFalse);
-      expect(matchesGlobPattern('**/*.g.dart', 'lib/models.g.dart.bak'), isFalse);
+      expect(
+        matchesGlobPattern('**/*.g.dart', 'lib/models.g.dart.bak'),
+        isFalse,
+      );
     });
 
     test('matches directory wildcard pattern', () {
@@ -59,11 +65,16 @@ void main() {
   group('Settings.loadFromAnalysisOptions', () {
     late Directory tempDir;
 
-    setUp(() => tempDir = Directory.systemTemp.createTempSync('prefer_shorthands_test_'));
+    setUp(
+      () => tempDir = Directory.systemTemp.createTempSync(
+        'prefer_shorthands_test_',
+      ),
+    );
     tearDown(() => tempDir.deleteSync(recursive: true));
 
-    void writeOptions(String content) =>
-        File('${tempDir.path}/analysis_options.yaml').writeAsStringSync(content);
+    void writeOptions(String content) => File(
+      '${tempDir.path}/analysis_options.yaml',
+    ).writeAsStringSync(content);
 
     test('reads analyzer.exclude patterns', () {
       writeOptions('''
@@ -126,12 +137,18 @@ prefer_shorthands:
   group('Settings.isExcluded', () {
     test('excludes file matching pattern', () {
       final settings = Settings(excludePatterns: ['**/*.g.dart']);
-      expect(settings.isExcluded('/project/lib/model.g.dart', '/project'), isTrue);
+      expect(
+        settings.isExcluded('/project/lib/model.g.dart', '/project'),
+        isTrue,
+      );
     });
 
     test('does not exclude non-matching file', () {
       final settings = Settings(excludePatterns: ['**/*.g.dart']);
-      expect(settings.isExcluded('/project/lib/model.dart', '/project'), isFalse);
+      expect(
+        settings.isExcluded('/project/lib/model.dart', '/project'),
+        isFalse,
+      );
     });
 
     test('excludes nested file matching pattern', () {
@@ -144,7 +161,10 @@ prefer_shorthands:
 
     test('returns false when excludePatterns is empty', () {
       const settings = Settings();
-      expect(settings.isExcluded('/project/lib/model.g.dart', '/project'), isFalse);
+      expect(
+        settings.isExcluded('/project/lib/model.g.dart', '/project'),
+        isFalse,
+      );
     });
 
     test('works when rootPath is empty', () {

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -520,6 +520,33 @@ enum Direction { left, right, up, down }
     );
   }
 
+  void test_exclusion_g_dart_file_is_skipped() async {
+    plugin.settings = Settings(
+      convertImplicitDeclaration: false,
+      excludePatterns: ['**/*.g.dart'],
+    );
+    const code = '''
+enum Direction { left, right }
+Direction dir = Direction.left;
+''';
+    final file = newFile('$testPackageLibPath/model.g.dart', code);
+    await assertDiagnosticsInFile(file.path, []);
+  }
+
+  void test_exclusion_regular_file_is_linted() async {
+    plugin.settings = Settings(
+      convertImplicitDeclaration: false,
+      excludePatterns: ['**/*.g.dart'],
+    );
+    await assertDiagnostics(
+      '''
+enum Direction { left, right }
+Direction dir = Direction.left;
+''',
+      [lint(47, 14)],
+    );
+  }
+
   /// https://github.com/huanghui1998hhh/prefer_shorthands/issues/21
   /// Factory constructors with body should NOT trigger warning
   /// Redirecting factory constructors SHOULD trigger warning


### PR DESCRIPTION
Fixes #7 by reading the current `exclude` section from `analysis_options.yaml`, if there is one.